### PR TITLE
[FIX] Misspelled migration as migratation

### DIFF
--- a/openeducat_activity/i18n/openeducat_activity.pot
+++ b/openeducat_activity/i18n/openeducat_activity.pot
@@ -116,16 +116,12 @@ msgid "Student"
 msgstr ""
 
 #. module: openeducat_activity
-#: model:ir.ui.menu,name:openeducat_activity.menu_student_migrate
-msgid "Student Migratation"
-msgstr ""
-
-#. module: openeducat_activity
 #: view:student.migrate:openeducat_activity.student_migrate_form
 msgid "Student Migrate"
 msgstr ""
 
 #. module: openeducat_activity
+#: model:ir.ui.menu,name:openeducat_activity.menu_student_migrate
 #: model:ir.actions.act_window,name:openeducat_activity.act_open_student_migrate_view
 msgid "Student Migration"
 msgstr ""


### PR DESCRIPTION
I found this while translating