### PR TITLE
FIX Student's Kanban view

### DIFF
--- a/openeducat_core/views/student_view.xml
+++ b/openeducat_core/views/student_view.xml
@@ -13,7 +13,7 @@
                             <div t-attf-class="oe_kanban_global_click o_res_partner_kanban">
                                 <div class="o_kanban_image">
                                     <t t-if="record.image.value">
-                                        <img t-att-src="kanban_image('op.student', 'image', record.id.value)"
+                                        <img t-att-src="kanban_image('op.student', 'image', record.id.raw_value)"
                                              alt="Student"/>
                                     </t>
                                     <t t-if="!record.image.value">


### PR DESCRIPTION
record.id.value gets translated in some languages, which inserts ',' in integer values.
Here in the logs, the ID of record is 2164 but it is converted to 2,164. Which gives the error logs as well breaks the images on Kanban View because image gets the URL like 
http://ps.v120.mylocal.com/web/image?model=op.student&field=image&id=2%2C142&unique=

id=2%2C142 was supposed to be id=2142

![image](https://user-images.githubusercontent.com/6999933/74356008-90ae9000-4db5-11ea-9660-30e68c2e1325.png)
