### PR TITLE
[13.0] Fix multi company issue

### DIFF
--- a/openeducat_admission/models/admission_register.py
+++ b/openeducat_admission/models/admission_register.py
@@ -71,6 +71,9 @@ class OpAdmissionRegister(models.Model):
                                        'Terms', readonly=True,
                                        states={'draft': [('readonly', False)]},
                                        tracking=True)
+    company_id = fields.Many2one(
+        'res.company', string='Company',
+        default=lambda self: self.env.user.company_id)
 
     @api.constrains('start_date', 'end_date')
     def check_dates(self):

--- a/openeducat_core/models/student.py
+++ b/openeducat_core/models/student.py
@@ -95,7 +95,9 @@ class OpStudent(models.Model):
                                         'Course Details',
                                         track_visibility='onchange')
     active = fields.Boolean(default=True)
-
+    company_id = fields.Many2one('res.company', string='Company',
+                                default=lambda self: self.env.user.company_id)
+        
     _sql_constraints = [(
         'unique_gr_no',
         'unique(gr_no)',


### PR DESCRIPTION
Pull request #553 added added company_id to op.admission only and modify get_student_vals method to get company_id from admission register and set company_id for student but the company_id field not exists in op.admission.register and op.student.

This pull request add company_id  to op.admission.register and op.student.