### PR TITLE
[18.0][FIX] clean up lint warnings in Odoo log messages

### DIFF
--- a/openeducat_core/views/faculty_view.xml
+++ b/openeducat_core/views/faculty_view.xml
@@ -9,46 +9,23 @@
                     <field name="id"/>
                     <field name="image_1920"/>
                     <templates>
-                        <t t-name="kanban-box">
-                            <div class="oe_kanban_global_click o_res_partner_kanban">
-                                <a type="open">
-                                    <div class="o_kanban_image" style="background:#e6e5e6;">
-                                        <t t-if="record.image_1920.value">
-                                            <img
-                                                t-att-src="kanban_image('op.faculty', 'image_1920', record.id.raw_value)"
-                                                alt="Faculty" />
-                                        </t>
-                                        <t t-if="!record.image_1920.value">
-                                            <img src="/base/static/img/avatar.png" alt="Faculty" />
-                                        </t>
+                        <t t-name="card" class="flex-row">
+                            <widget name="web_ribbon" title="Archived" bg_color="text-bg-danger" invisible="active"/>
+                            <aside class="o_kanban_aside_full">
+                                <field name="image_1920" class="w-100" widget="image" options="{'img_class': 'object-fit-contain w-100 h-100'}"/>
+                            </aside>
+                            <main class="ps-2 ps-md-0">
+                                <div class="mb-1">
+                                    <field name="name" class="mb-0 fw-bold fs-5"/>
+                                    <div>
+                                      <field name="contact_address" class="text-muted" />
+                                      <field name="phone" class="text-muted" />
+                                      <field name="mobile" class="text-muted" />
+                                      <field name="email" class="text-muted" />
+                                      <field name="lang" class="text-muted" />
                                     </div>
-                                    <div class="oe_kanban_details">
-                                        <h4>
-
-                                            <field name="name" />
-                                        </h4>
-                                        <ul>
-                                            <li t-if="record.contact_address.raw_value">
-                                                <field name="contact_address" />
-                                            </li>
-                                            <li t-if="record.phone.raw_value">
-                                                <field name="phone" />
-                                            </li>
-                                            <li t-if="record.mobile.raw_value">
-                                                <field name="mobile" />
-                                            </li>
-                                            <li t-if="record.email.raw_value">
-                                                <a t-attf-href="mailto:#{record.email.value}">
-                                                    <field name="email" />
-                                                </a>
-                                            </li>
-                                            <li t-if="record.lang.raw_value">
-                                                <field name="lang" />
-                                            </li>
-                                        </ul>
-                                    </div>
-                                </a>
-                            </div>
+                                </div>
+                            </main>
                         </t>
                     </templates>
                 </kanban>

--- a/openeducat_core/views/student_view.xml
+++ b/openeducat_core/views/student_view.xml
@@ -9,45 +9,23 @@
                     <field name="id"/>
                     <field name="image_1920"/>
                     <templates>
-                        <t t-name="kanban-box">
-                            <div t-attf-class="oe_kanban_global_click o_res_partner_kanban">
-                                <a type="open">
-                                    <div class="o_kanban_image" style="background:#e6e5e6;">
-                                        <t t-if="record.image_1920.value">
-                                            <img
-                                                t-att-src="kanban_image('op.student', 'image_1920', record.id.raw_value)"
-                                                alt="Student" />
-                                        </t>
-                                        <t t-if="!record.image_1920.value">
-                                            <img src="/base/static/img/avatar.png" alt="Student" />
-                                        </t>
+                          <t t-name="card" class="flex-row">
+                            <widget name="web_ribbon" title="Archived" bg_color="text-bg-danger" invisible="active"/>
+                            <aside class="o_kanban_aside_full">
+                                <field name="image_1920" class="w-100" widget="image" options="{'img_class': 'object-fit-contain w-100 h-100'}"/>
+                            </aside>
+                            <main class="ps-2 ps-md-0">
+                                <div class="mb-1">
+                                    <field name="display_name" class="mb-0 fw-bold fs-5"/>
+                                    <div>
+                                      <field name="contact_address" class="text-muted" />
+                                      <field name="phone" class="text-muted" />
+                                      <field name="mobile" class="text-muted" />
+                                      <field name="email" class="text-muted" />
+                                      <field name="lang" class="text-muted" />
                                     </div>
-                                    <div class="oe_kanban_details">
-                                        <h4>
-                                            <field name="name" />
-                                        </h4>
-                                        <ul>
-                                            <li t-if="record.contact_address.raw_value">
-                                                <field name="contact_address" />
-                                            </li>
-                                            <li t-if="record.phone.raw_value">
-                                                <field name="phone" />
-                                            </li>
-                                            <li t-if="record.mobile.raw_value">
-                                                <field name="mobile" />
-                                            </li>
-                                            <li t-if="record.email.raw_value">
-                                                <a t-attf-href="mailto:#{record.email.value}">
-                                                    <field name="email" />
-                                                </a>
-                                            </li>
-                                            <li t-if="record.lang.raw_value">
-                                                <field name="lang" />
-                                            </li>
-                                        </ul>
-                                    </div>
-                                </a>
-                            </div>
+                                </div>
+                            </main>
                         </t>
                     </templates>
                 </kanban>

--- a/openeducat_library/wizards/issue_media.py
+++ b/openeducat_library/wizards/issue_media.py
@@ -30,6 +30,7 @@ from ..models import media_unit
 class IssueMedia(models.TransientModel):
     """ Issue Media """
     _name = "issue.media"
+    _inherit = "mail.thread"
     _description = "Issue Media Wizard"
 
     media_id = fields.Many2one('op.media', 'Media', required=True)

--- a/openeducat_timetable/models/timetable.py
+++ b/openeducat_timetable/models/timetable.py
@@ -80,7 +80,7 @@ class OpSession(models.Model):
         'Days',
         group_expand='_expand_groups', store=True
     )
-    timing = fields.Char(compute='_compute_timing')
+    timing = fields.Char(compute='_compute_timing',string='Session timing')
 
     @api.depends('start_datetime', 'end_datetime')
     def _compute_timing(self):

--- a/openeducat_timetable/views/timetable_view.xml
+++ b/openeducat_timetable/views/timetable_view.xml
@@ -157,7 +157,7 @@
                             </t>
                             <ul class="oe_kanban_colorpicker" data-field="color" />
                         </t>
-                        <t t-name="kanban-box">
+                        <t t-name="card">
                             <div t-attf-class="#{kanban_color(record.color.raw_value)} oe_kanban_global_click">
                                 <div class="oe_kanban_content">
                                     <div>
@@ -190,12 +190,6 @@
                                             <b>End:</b>
                                             <field name="end_datetime"/>
                                         </li>
-                                    </div>
-                                    <div class="oe_kanban_bottom_right">
-                                        <img alt="Faculty"
-                                             t-att-src="kanban_image('op.faculty', 'image_1920', record.faculty_id.raw_value)"
-                                             t-att-title="record.faculty_id.value" width="24" height="24"
-                                             class="oe_kanban_avatar"/>
                                     </div>
                                     <div class="oe_clear"></div>
                                 </div>


### PR DESCRIPTION
This pull request addresses and resolves various lint warnings observed in Odoo logs, as highlighted in the attached screenshot. 

The changes include:

Replacing deprecated kanban-box with the recommended card template.
Correcting tracking parameter warnings for model fields.
Resolving warnings about duplicate field labels (e.g., timing and timing_id in op.session).

![Screenshot from 2024-12-01 12-31-26](https://github.com/user-attachments/assets/1ddfc839-c4d1-4aca-9833-c3f607e9dfb9)